### PR TITLE
Remove Sphinx from dev dependencies

### DIFF
--- a/dev_environment.in
+++ b/dev_environment.in
@@ -1,4 +1,4 @@
 pytest
 pytest-cov
 pytest-flake8
-sphinx
+six

--- a/dev_environment.txt
+++ b/dev_environment.txt
@@ -5,23 +5,13 @@
 #    pip-compile --output-file dev_environment.txt dev_environment.in
 #
 
-alabaster==0.7.8          # via sphinx
-babel==2.3.4              # via sphinx
 coverage==4.1             # via pytest-cov
-docutils==0.12            # via sphinx
 flake8==2.6.0             # via pytest-flake8
-imagesize==0.7.1          # via sphinx
-Jinja2==2.8               # via sphinx
-MarkupSafe==0.23          # via jinja2
 mccabe==0.5.0             # via flake8
 py==1.4.31                # via pytest
 pycodestyle==2.0.0        # via flake8
 pyflakes==1.2.3           # via flake8
-Pygments==2.1.3           # via sphinx
 pytest-cov==2.2.1
 pytest-flake8==0.5
 pytest==2.9.2
-pytz==2016.4              # via babel
-six==1.10.0               # via sphinx
-snowballstemmer==1.2.1    # via sphinx
-sphinx==1.4.4
+six==1.10.0

--- a/tox.ini
+++ b/tox.ini
@@ -4,9 +4,13 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py27, py34, py35
+envlist = py27, py34, py35, docs
 
 [testenv]
 commands = py.test
 deps =
     -rdev_environment.txt
+
+[testenv:docs]
+commands=python setup.py build_sphinx
+deps = sphinx


### PR DESCRIPTION
It should only be installed in jobs building documentation.
